### PR TITLE
fix: Fix for creating clients with passwords and roles

### DIFF
--- a/src/main/java/com/organize/dto/ClientDataRequestDTO.java
+++ b/src/main/java/com/organize/dto/ClientDataRequestDTO.java
@@ -5,7 +5,8 @@ import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
 public record ClientDataRequestDTO(
-        @NotNull(message = "ID do cliente é obrigatório") UUID clientId,
-
+        @NotNull(message = "nome é um campo obrigatório") String name,
+        @NotNull(message = "email é um campo obrigatório") String email,
+        @NotNull(message = "telefone é um campo obrigatório") String phone,
         String privateNotes) {
 }


### PR DESCRIPTION
     - Previously: When creating a client, the password was not set, generating a NOT NULL error in the 'users' table.
     - Roles were not assigned, leaving the client without proper permissions.
     - The service constructor did not inject PasswordEncoder, which prevents password encryption.

     Fix:
     - Set the client's password to the phone number, encrypted with PasswordEncoder.
     - Set the client's role to ROLE_CUSTOMER.
     - Adjust the ClientDataService constructor to receive PasswordEncoder via DI.
     - Prevents logic conflicts between the logged-in user and the created client.