### PR TITLE
feat: Implements user profile management endpoints

### DIFF
--- a/src/main/java/com/organize/controller/MeController.java
+++ b/src/main/java/com/organize/controller/MeController.java
@@ -1,0 +1,42 @@
+package com.organize.controller;
+
+import com.organize.dto.ChangePasswordRequestDTO;
+import com.organize.dto.ProfileResponseDTO;
+import com.organize.dto.UpdateProfileRequestDTO;
+import com.organize.model.User; 
+import com.organize.service.MeService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/me")
+@RequiredArgsConstructor
+public class MeController {
+
+    private final MeService meService;
+
+    @GetMapping
+    public ResponseEntity<ProfileResponseDTO> getMyProfile(@AuthenticationPrincipal User currentUser) {
+        ProfileResponseDTO profile = meService.getUserProfile(currentUser.getId());
+        return ResponseEntity.ok(profile);
+    }
+
+    @PutMapping
+    public ResponseEntity<ProfileResponseDTO> updateMyProfile(
+        @AuthenticationPrincipal User currentUser,
+        @Valid @RequestBody UpdateProfileRequestDTO dto) {
+        ProfileResponseDTO updatedProfile = meService.updateUserProfile(currentUser.getId(), dto);
+        return ResponseEntity.ok(updatedProfile);
+    }
+
+    @PutMapping("/password")
+    public ResponseEntity<Void> changeMyPassword(
+        @AuthenticationPrincipal User currentUser,
+        @Valid @RequestBody ChangePasswordRequestDTO dto) {
+        meService.changeUserPassword(currentUser.getId(), dto);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/organize/dto/ChangePasswordRequestDTO.java
+++ b/src/main/java/com/organize/dto/ChangePasswordRequestDTO.java
@@ -1,0 +1,13 @@
+package com.organize.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ChangePasswordRequestDTO(
+    @NotBlank(message = "A senha antiga é obrigatória")
+    String oldPassword,
+
+    @NotBlank(message = "A nova senha é obrigatória")
+    @Size(min = 8, message = "A nova senha deve ter no mínimo 8 caracteres")
+    String newPassword
+) {}

--- a/src/main/java/com/organize/dto/ProfileResponseDTO.java
+++ b/src/main/java/com/organize/dto/ProfileResponseDTO.java
@@ -1,0 +1,10 @@
+package com.organize.dto;
+
+import java.util.UUID;
+
+public record ProfileResponseDTO(
+    UUID id,
+    String name,
+    String email,
+    String phone
+) {}

--- a/src/main/java/com/organize/dto/UpdateProfileRequestDTO.java
+++ b/src/main/java/com/organize/dto/UpdateProfileRequestDTO.java
@@ -1,0 +1,10 @@
+package com.organize.dto;
+
+import jakarta.validation.constraints.Email;
+
+public record UpdateProfileRequestDTO(
+    String name,
+
+    @Email(message = "Formato de email inválido se fornecido")
+    String email
+) {}

--- a/src/main/java/com/organize/repository/UserRepository.java
+++ b/src/main/java/com/organize/repository/UserRepository.java
@@ -1,14 +1,20 @@
 package com.organize.repository;
 
-import com.organize.model.Role;
 import com.organize.model.User;
+import com.organize.model.Role; 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+@Repository
 public interface UserRepository extends JpaRepository<User, UUID> {
+
     Optional<User> findByEmail(String email);
+
     List<User> findByRolesContaining(Role role);
+
+    boolean existsByEmailAndIdNot(String email, UUID id);
 }

--- a/src/main/java/com/organize/service/MeService.java
+++ b/src/main/java/com/organize/service/MeService.java
@@ -1,0 +1,12 @@
+package com.organize.service;
+
+import com.organize.dto.ChangePasswordRequestDTO;
+import com.organize.dto.ProfileResponseDTO;
+import com.organize.dto.UpdateProfileRequestDTO;
+import java.util.UUID;
+
+public interface MeService {
+    ProfileResponseDTO getUserProfile(UUID userId);
+    ProfileResponseDTO updateUserProfile(UUID userId, UpdateProfileRequestDTO dto);
+    void changeUserPassword(UUID userId, ChangePasswordRequestDTO dto);
+}

--- a/src/main/java/com/organize/service/MeServiceImpl.java
+++ b/src/main/java/com/organize/service/MeServiceImpl.java
@@ -1,0 +1,66 @@
+package com.organize.service;
+
+import com.organize.dto.ChangePasswordRequestDTO;
+import com.organize.dto.ProfileResponseDTO;
+import com.organize.dto.UpdateProfileRequestDTO;
+import com.organize.model.User;
+import com.organize.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class MeServiceImpl implements MeService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    @Transactional(readOnly = true)
+    public ProfileResponseDTO getUserProfile(UUID userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("Usuário não encontrado"));
+        return new ProfileResponseDTO(user.getId(), user.getName(), user.getEmail(), user.getPhone());
+    }
+
+    @Override
+    @Transactional
+    public ProfileResponseDTO updateUserProfile(UUID userId, UpdateProfileRequestDTO dto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("Usuário não encontrado"));
+
+        
+        if (dto.name() != null && !dto.name().isBlank()) {
+            user.setName(dto.name());
+        }
+
+        if (dto.email() != null && !dto.email().isBlank()) {
+            if (userRepository.existsByEmailAndIdNot(dto.email(), userId)) {
+                throw new IllegalArgumentException("O e-mail informado já está em uso.");
+            }
+            user.setEmail(dto.email());
+        }
+
+        User updatedUser = userRepository.save(user);
+        return new ProfileResponseDTO(updatedUser.getId(), updatedUser.getName(), updatedUser.getEmail(), updatedUser.getPhone());
+    }
+
+    @Override
+    @Transactional
+    public void changeUserPassword(UUID userId, ChangePasswordRequestDTO dto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("Usuário não encontrado"));
+
+        if (!passwordEncoder.matches(dto.oldPassword(), user.getPassword())) {
+            throw new IllegalArgumentException("Senha antiga incorreta.");
+        }
+
+        user.setPassword(passwordEncoder.encode(dto.newPassword()));
+        userRepository.save(user);
+    }
+}


### PR DESCRIPTION
Criação do MeController com 3 novos endpoints dedicados ao usuário logado:

GET /api/me: Para buscar os dados do perfil.

PUT /api/me: Para atualizações parciais de nome e/ou e-mail.

PUT /api/me/password: Para alteração segura de senha (exige a senha antiga).

Adição da camada de serviço (MeService e MeServiceImpl) para conter a lógica de negócio.

Criação dos DTOs necessários (ProfileResponseDTO, UpdateProfileRequestDTO, ChangePasswordRequestDTO) para garantir a comunicação segura e validada.

Atualização do SecurityConfig para proteger as novas rotas, garantindo que apenas usuários autenticados possam acessar seu próprio perfil.

Ajuste no UserRepository para permitir validações de e-mail duplicado.